### PR TITLE
Don't require integer primary keys

### DIFF
--- a/project_example/project_example/apps/test_salmonella/admin.py
+++ b/project_example/project_example/apps/test_salmonella/admin.py
@@ -2,12 +2,13 @@ from django.contrib import admin
 
 from salmonella.admin import SalmonellaMixin
 
-from .models import SalmonellaTest, DirectPrimaryKeyModel
+from .models import SalmonellaTest, DirectPrimaryKeyModel, CharPrimaryKeyModel
 
 
 class SalmonellaTestAdmin(SalmonellaMixin, admin.ModelAdmin):
     raw_id_fields = ('rawid_fk', 'rawid_fk_limited', 'rawid_many')
-    salmonella_fields = ('salmonella_fk', 'salmonella_fk_limited', 'salmonella_many', 'salmonella_fk_direct_pk')
+    salmonella_fields = ('salmonella_fk', 'salmonella_fk_limited', 'salmonella_many', 'salmonella_fk_direct_pk', 'salmonella_fk_char_pk')
 
 admin.site.register(DirectPrimaryKeyModel)
+admin.site.register(CharPrimaryKeyModel)
 admin.site.register(SalmonellaTest, SalmonellaTestAdmin)

--- a/project_example/project_example/apps/test_salmonella/models.py
+++ b/project_example/project_example/apps/test_salmonella/models.py
@@ -3,6 +3,9 @@ from django.db import models
 class DirectPrimaryKeyModel(models.Model):
     num = models.IntegerField("Number", primary_key=True)
 
+class CharPrimaryKeyModel(models.Model):
+    chr = models.CharField(max_length=20, primary_key=True)
+
 
 class SalmonellaTest(models.Model):
     rawid_fk = models.ForeignKey('auth.User',
@@ -32,3 +35,6 @@ class SalmonellaTest(models.Model):
 
     salmonella_fk_direct_pk = models.ForeignKey(DirectPrimaryKeyModel,
         related_name='salmonella_fk_direct_pk', blank=True, null=True)
+
+    salmonella_fk_char_pk = models.ForeignKey(CharPrimaryKeyModel,
+            related_name='salmonella_fk_char_pk', blank=True, null=True)

--- a/salmonella/views.py
+++ b/salmonella/views.py
@@ -21,11 +21,7 @@ def label_view(request, app_name, model_name, template_name="", multi=False,
     # in case the user entered values by hand, such as '1, 2,3'.
     object_list = []
     for pk in request.GET['id'].split(","):
-        try:
-            object_list.append(int(pk))
-        # Not an integer, not convertable
-        except ValueError:
-            pass
+        object_list.append(pk.strip())
 
     # Check if at least one value survived this cleanup.
     if len(object_list) == 0:
@@ -64,6 +60,10 @@ def label_view(request, app_name, model_name, template_name="", multi=False,
             extra_context = {
                 template_object_name: (obj, change_url),
             }
+    # most likely the pk wasn't convertable
+    except ValueError:
+        msg = 'ValueError during lookup'
+        return HttpResponseBadRequest(settings.DEBUG and msg or '')
     except model.DoesNotExist:
         msg = 'Model instance does not exist'
         return HttpResponseBadRequest(settings.DEBUG and msg or '')


### PR DESCRIPTION
Django doesn't require primary keys to be integers, so
don't force the given primary key to be one. Django will
attempt to convert the given string to the primary key type
and will raise a ValueError otherwise.

This fixes issue #23
