### PR TITLE
Need a few extra directives in setup.py to ensure static media is bundled.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
         'templates/salmonella/admin/*.html',
         'templates/salmonella/admin/widgets/*.html'
     ]},
+    include_package_data=True,
     url="http://github.com/lincolnloop/django-salmonella/",
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
As the title says :)

Without these the appropriate static assets never make it to the server if you install with pip from github.
