### PR TITLE
Fixed: Ensure proper ordering when loading JS

### DIFF
--- a/dynamic_raw_id/widgets.py
+++ b/dynamic_raw_id/widgets.py
@@ -85,8 +85,16 @@ class DynamicRawIDWidget(widgets.ForeignKeyRawIdWidget):
         })
         return context
 
-    class Media:
-        js = ("dynamic_raw_id/js/dynamic_raw_id.js",)
+    @property
+    def media(self):
+        extra = '' if settings.DEBUG else '.min'
+        js = [
+            'admin/js/vendor/jquery/jquery%s.js' % extra,
+            'admin/js/jquery.init.js',
+            'admin/js/core.js',
+            "dynamic_raw_id/js/dynamic_raw_id.js"
+            ]
+        return forms.Media(js=js)
 
 
 class DynamicRawIDMultiIdWidget(DynamicRawIDWidget):

--- a/dynamic_raw_id/widgets.py
+++ b/dynamic_raw_id/widgets.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django import forms
 from django.contrib.admin import widgets
 from django.core.exceptions import ImproperlyConfigured
 from django.template.loader import render_to_string


### PR DESCRIPTION
Django 2.0 changed the way in which form media were loaded. (See: django/django@c19b56f and https://code.djangoproject.com/ticket/28377). This change meant that the Salmonella JS was loaded before jQuery.

This commit specifies the order in which the JS should load for this widget. Any duplicate entries will be filtered out.