### PR TITLE
Update dynamic_raw_id.js to support custom admin url

### DIFF
--- a/dynamic_raw_id/static/dynamic_raw_id/js/dynamic_raw_id.js
+++ b/dynamic_raw_id/static/dynamic_raw_id/js/dynamic_raw_id.js
@@ -22,7 +22,7 @@ function dismissRelatedLookupPopup(win, chosenId) {
         model = element.next("a").attr("data-model"),
         value = element.val(),
         ADMIN_URL = window.DYNAMIC_RAW_ID_MOUNT_URL || "/admin/",
-        MOUNT_URL = ADMIN_URL + 'salmonella',
+        MOUNT_URL = ADMIN_URL + "salmonella",
         admin_url_parts = window.location.pathname.split("/").slice(1, 4);
 
       var url = MOUNT_URL;

--- a/dynamic_raw_id/static/dynamic_raw_id/js/dynamic_raw_id.js
+++ b/dynamic_raw_id/static/dynamic_raw_id/js/dynamic_raw_id.js
@@ -21,7 +21,8 @@ function dismissRelatedLookupPopup(win, chosenId) {
         app = element.next("a").attr("data-app"),
         model = element.next("a").attr("data-model"),
         value = element.val(),
-        MOUNT_URL = window.DYNAMIC_RAW_ID_MOUNT_URL || "/admin/dynamic_raw_id",
+        ADMIN_URL = window.DYNAMIC_RAW_ID_MOUNT_URL || "/admin/",
+        MOUNT_URL = ADMIN_URL + 'salmonella',
         admin_url_parts = window.location.pathname.split("/").slice(1, 4);
 
       var url = MOUNT_URL;

--- a/dynamic_raw_id/static/dynamic_raw_id/js/dynamic_raw_id.js
+++ b/dynamic_raw_id/static/dynamic_raw_id/js/dynamic_raw_id.js
@@ -22,7 +22,7 @@ function dismissRelatedLookupPopup(win, chosenId) {
         model = element.next("a").attr("data-model"),
         value = element.val(),
         ADMIN_URL = window.DYNAMIC_RAW_ID_MOUNT_URL || "/admin/",
-        MOUNT_URL = ADMIN_URL + "salmonella",
+        MOUNT_URL = ADMIN_URL + "dynamic_raw_id",
         admin_url_parts = window.location.pathname.split("/").slice(1, 4);
 
       var url = MOUNT_URL;


### PR DESCRIPTION
According to the documentation, if used with custom admin url, all that's needed is to set `DYNAMIC_RAW_ID_MOUNT_URL` in the `admin/base_site.html`. Your example suggests using `{% url  'admin:index' %}` which will resolve to `/my-custom-admin-url/`. But your javascript file expects `/my-custom-admin-url/salmonella`.
This change should do the trick.