### PR TITLE
Fix path to clear action image, update alt attribute

### DIFF
--- a/dynamic_raw_id/templates/dynamic_raw_id/admin/widgets/dynamic_raw_id_field.html
+++ b/dynamic_raw_id/templates/dynamic_raw_id/admin/widgets/dynamic_raw_id_field.html
@@ -6,6 +6,6 @@
     <img src="{% static "dynamic_raw_id/img/selector-search.gif" %}" alt="Lookup" height="16" width="16">
 </a>
 <a data-name="developers" data-app="{{ app_name }}" data-model="{{ model_name }}" class="dynamic_raw_id-clear-field">
-    <img src="{% static "img/icon_deletelink.gif" %}" alt="Lookup" height="10" width="10">
+    <img src="{% static "dynamic_raw_id/img/icon_deletelink.gif" %}" alt="Clear" height="10" width="10">
 </a>
 <span class="dynamic_raw_id_label" id="{{ name }}_dynamic_raw_id_label"></span>


### PR DESCRIPTION
The alt attribute is incorrect, the path to Clear action image is broken:
![pasted image at 2018_04_02_08_44 am_big](https://user-images.githubusercontent.com/867864/38204004-2a058a20-366f-11e8-98a5-e8b54bdb29b9.png)
