### PR TITLE
Preparing for Django 3.0 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 testapp.db
 geckodriver.log
 coverage_report
+.coverage

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+v2.7 (2019-09-19)
+=======================
+- Django 3.0alpha compatibility
+- Replace `render_to_response` with `render`
+- Replace `django.utils.six` with `six`
+- Remove unneeded "dunder" methods from test settings in `runtests.py`
+- Replace `staticfiles` and `admin_static`
+
 v2.6 (2019-06-21)
 =================
 

--- a/dynamic_raw_id/admin.py
+++ b/dynamic_raw_id/admin.py
@@ -8,7 +8,7 @@ class DynamicRawIDMixin(object):
 
     def formfield_for_foreignkey(self, db_field, request=None, **kwargs):
         if db_field.name in self.dynamic_raw_id_fields:
-            rel = db_field.remote_field if VERSION[0] == 2 else db_field.rel
+            rel = db_field.remote_field if VERSION[0] >= 2 else db_field.rel
             kwargs['widget'] = DynamicRawIDWidget(rel, self.admin_site)
             return db_field.formfield(**kwargs)
         return super(DynamicRawIDMixin, self).formfield_for_foreignkey(
@@ -17,7 +17,7 @@ class DynamicRawIDMixin(object):
 
     def formfield_for_manytomany(self, db_field, request=None, **kwargs):
         if db_field.name in self.dynamic_raw_id_fields:
-            rel = db_field.remote_field if VERSION[0] == 2 else db_field.rel
+            rel = db_field.remote_field if VERSION[0] >= 2 else db_field.rel
             kwargs['widget'] = DynamicRawIDMultiIdWidget(rel, self.admin_site)
             kwargs['help_text'] = ''
             return db_field.formfield(**kwargs)

--- a/dynamic_raw_id/filters.py
+++ b/dynamic_raw_id/filters.py
@@ -34,7 +34,7 @@ class DynamicRawIDFilter(admin.filters.FieldListFilter):
         super(DynamicRawIDFilter, self).__init__(
             field, request, params, model, model_admin, field_path
         )
-        rel = field.remote_field if VERSION[0] == 2 else field.rel
+        rel = field.remote_field if VERSION[0] >= 2 else field.rel
         self.form = self.get_form(request, rel, model_admin.admin_site)
 
     def choices(self, cl):

--- a/dynamic_raw_id/templates/dynamic_raw_id/admin/filters/dynamic_raw_id_filter.html
+++ b/dynamic_raw_id/templates/dynamic_raw_id/admin/filters/dynamic_raw_id_filter.html
@@ -1,4 +1,4 @@
-{% load i18n admin_static %}
+{% load i18n static %}
 <h3>{% blocktrans with filter_title=title %} By {{ filter_title }} {% endblocktrans %}</h3>
 <link rel="stylesheet" type="text/css" href="{% static "admin/css/widgets.css" %}" />
 <style>

--- a/dynamic_raw_id/templates/dynamic_raw_id/admin/widgets/dynamic_raw_id_field.html
+++ b/dynamic_raw_id/templates/dynamic_raw_id/admin/widgets/dynamic_raw_id_field.html
@@ -1,4 +1,4 @@
-{% load static from staticfiles %}
+{% load static %}
 
 {% include 'django/forms/widgets/input.html' %}
 

--- a/dynamic_raw_id/tests/testapp/models.py
+++ b/dynamic_raw_id/tests/testapp/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.utils.six import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 
 
 @python_2_unicode_compatible

--- a/dynamic_raw_id/tests/testapp/settings.py
+++ b/dynamic_raw_id/tests/testapp/settings.py
@@ -48,3 +48,16 @@ STATICFILES_FINDERS = [
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
 ]
+
+TEST_SETTINGS = {
+    'DEBUG': DEBUG,
+    'SECRET_KEY': SECRET_KEY,
+    'DATABASES': DATABASES,
+    'TEMPLATES': TEMPLATES,
+    'INSTALLED_APPS': INSTALLED_APPS,
+    'MIDDLEWARE': MIDDLEWARE,
+    'STATIC_ROOT': STATIC_ROOT,
+    'STATIC_URL': STATIC_URL,
+    'ROOT_URLCONF': ROOT_URLCONF,
+    'STATICFILES_FINDERS': STATICFILES_FINDERS,
+}

--- a/dynamic_raw_id/views.py
+++ b/dynamic_raw_id/views.py
@@ -2,7 +2,7 @@ from django.apps import apps
 from django.conf import settings
 from django.contrib.auth.decorators import user_passes_test
 from django.http import HttpResponseBadRequest, HttpResponseForbidden
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.urls import reverse
 
 
@@ -74,4 +74,4 @@ def label_view(
         msg = 'Model instance does not exist'
         return HttpResponseBadRequest(settings.DEBUG and msg or '')
 
-    return render_to_response((model_template, template_name), extra_context)
+    return render(request, (model_template, template_name), extra_context)

--- a/dynamic_raw_id/widgets.py
+++ b/dynamic_raw_id/widgets.py
@@ -17,7 +17,7 @@ class DynamicRawIDWidget(widgets.ForeignKeyRawIdWidget):
         context = super(DynamicRawIDWidget, self).get_context(
             name, value, attrs
         )
-        model = self.rel.model if VERSION[0] == 2 else self.rel.to
+        model = self.rel.model if VERSION[0] >= 2 else self.rel.to
         related_url = reverse(
             'admin:{0}_{1}_changelist'.format(
                 model._meta.app_label, model._meta.object_name.lower()

--- a/runtests.py
+++ b/runtests.py
@@ -9,8 +9,8 @@ from django.test.runner import DiscoverRunner
 def runtests(*test_args):
     # Setup settings
     if not settings.configured:
-        from dynamic_raw_id.tests.testapp import settings as TEST_SETTINGS
-        settings.configure(**TEST_SETTINGS.__dict__)
+        from dynamic_raw_id.tests.testapp.settings import TEST_SETTINGS
+        settings.configure(**TEST_SETTINGS)
 
     setup()
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-dynamic-raw-id
-version = 2.6
+version = 2.7
 description = raw_id_fields widget replacement that handles display of an object's string value on change.
 long_description = file: README.rst, CHANGELOG.rst
 author = Martin Mahner, Seth Buntin, Yann Malet
@@ -28,7 +28,7 @@ zip_safe = False
 python_requires = >=2.7
 install_requires =
     django>=1.8
-    six
+    six>=1.10.0
 
 [options.extras_require]
 tests =

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist=
   begin
   py{27}-django-{111}
   py{35,36}-django-{111,20,21,22}
-  py{37}-django-{21,22}
+  py{37}-django-{21,22,30}
   end
 
 [testenv]
@@ -25,6 +25,7 @@ deps=
     django-20: django==2.0.*
     django-21: django==2.1.*
     django-22: django==2.2.*
+    django-30: django==3.0a1
 
 [testenv:begin]
 basepython = python3.6


### PR DESCRIPTION
Hi Maintainers! I was wondering if you could help me make a change to your library to support Django 3.0?

I'm working on a project that is preparing for Django 3.0 support and as part of that I can help update some of our dependencies. I hope I've covered the bases here for contributing. I ran `tox` locally and it doesn't break any worse than the current Travis builds show.

Let me know if there's anything I can do to improve this PR or complete anything in your process

Thanks!

# Notes
- Replace `render_to_response` with `render`
- Replace `django.utils.six` with `six`
- Remove unneeded "dunder" methods from test settings in `runtests.py`
- Replace `staticfiles` and `admin_static`