### PR TITLE
Compatibility with Django 3.1

### DIFF
--- a/dynamic_raw_id/static/dynamic_raw_id/js/dynamic_raw_id.js
+++ b/dynamic_raw_id/static/dynamic_raw_id/js/dynamic_raw_id.js
@@ -6,8 +6,7 @@
  * catch it and update the associated label.
  */
 function dismissRelatedLookupPopup(win, chosenId) {
-  const name = windowname_to_id(win.name);
-  const elem = document.getElementById(name);
+  const elem = document.getElementById(win.name);
   if (elem.className.indexOf('vManyToManyRawIdAdminField') !== -1 && elem.value) {
     elem.value += `,${chosenId}`;
   } else {


### PR DESCRIPTION
JS function `windowname_to_id` has been removed in Django 3.1. Appearently it was a workaround for older browsers which is no longer needed:

https://github.com/django/django/commit/f982f0bdb8317e75af416595c616943d5025da1e#diff-ec17958cc9f7c2542303557dfc4ad997L45-L121

https://code.djangoproject.com/ticket/31032