### PR TITLE
Update classifiers based on latest commit & compatibility matrix

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,11 +15,13 @@ classifiers =
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: 2.7
-    Programming Language :: Python :: 3.5
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Framework :: Django
+    Framework :: Django :: 3.2
+    Framework :: Django :: 4.0
 
 [options]
 packages = find:


### PR DESCRIPTION
Recent changes have been made, but the classifiers were out of date, which will reflect on PyPI. Updated to match latest project compatibility.