### PR TITLE
Restore value_from_datadict to widget so values don't get destroyed by commas

### DIFF
--- a/dynamic_raw_id/widgets.py
+++ b/dynamic_raw_id/widgets.py
@@ -48,6 +48,17 @@ class DynamicRawIDWidget(widgets.ForeignKeyRawIdWidget):
 
 
 class DynamicRawIDMultiIdWidget(DynamicRawIDWidget):
+    def value_from_datadict(
+            self,
+            data: dict[str, Any],
+            files: Any | None,
+            name: str,
+    ) -> str | None:
+        value = data.get(name)
+        if value:
+            return value.split(",")
+        return None
+
     def render(
         self,
         name: str,


### PR DESCRIPTION
During the 4.0 upgrade process, a small function that was apparently important (at least for my site) was removed.  This PR restores it.

[Ref this issue](https://github.com/lincolnloop/django-dynamic-raw-id/issues/103)